### PR TITLE
Too many binlog connection issue

### DIFF
--- a/include/binlog_api.h
+++ b/include/binlog_api.h
@@ -68,6 +68,8 @@ public:
 
   virtual int connect() { return 1; }
 
+  virtual int disconnect() { return 1; }
+
   virtual int wait_for_next_event(mysql::Binary_log_event **event) {
     return ERR_EOF;
   }
@@ -109,6 +111,8 @@ public:
   }
 
   int connect();
+
+  int disconnect();
 
   /**
    * Blocking attempt to get the next binlog event from the stream

--- a/include/binlog_driver.h
+++ b/include/binlog_driver.h
@@ -46,6 +46,10 @@ public:
    */
   virtual int connect()= 0;
 
+  /**
+   * Disconnect the currently running binary log session
+   */
+  virtual int disconnect()= 0;
 
   /**
    * Blocking attempt to get the next binlog event from the stream

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -44,9 +44,12 @@ class Binlog_tcp_driver : public Binary_log_driver
 public:
 
     Binlog_tcp_driver(const std::string& user, const std::string& passwd,
-                      const std::string& host, unsigned long port)
-      : Binary_log_driver("", 4), m_host(host), m_user(user), m_passwd(passwd),
-        m_port(port), m_socket(NULL), m_waiting_event(0), m_event_loop(0),
+                      const std::string& host, unsigned long port,
+                      const std::string& binlog_file,
+                      unsigned long binlog_offset)
+      : Binary_log_driver(binlog_file, binlog_offset),
+        m_host(host), m_user(user), m_passwd(passwd), m_port(port),
+        m_socket(NULL), m_waiting_event(0), m_event_loop(0),
         m_total_bytes_transferred(0), m_shutdown(false),
         m_event_queue(new bounded_buffer<Binary_log_event*>(50))
     {

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -58,13 +58,7 @@ public:
     ~Binlog_tcp_driver()
     {
       disconnect();
-      m_io_service.post(boost::bind(&Binlog_tcp_driver::shutdown, this));
-      if (m_event_loop){
-        m_event_loop->join();
-        delete m_event_loop;
-      }
-        delete m_event_queue;
-        delete m_socket;
+      delete m_event_queue;
     }
 
     /**
@@ -119,6 +113,11 @@ private:
      *
      */
     void start_binlog_dump(const std::string &binlog_file_name, size_t offset);
+
+    /**
+     * Stop the event loop thread
+     */
+    void stop_binlog_dump();
 
     /**
      * Handles a completed mysql server package header and put a

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -67,6 +67,12 @@ public:
     int connect();
 
     /**
+     * Disconnet from the server.
+     * The event queue is emptied.
+     */
+    int disconnect();
+
+    /**
      * Blocking wait for the next binary log event to reach the client
      */
     int wait_for_next_event(mysql::Binary_log_event **event);
@@ -163,13 +169,6 @@ private:
      * Reconnect to the server by first calling disconnect and then connect.
      */
     void reconnect(void);
-
-    /**
-     * Disconnet from the server. The io service must have been stopped before
-     * this function is called.
-     * The event queue is emptied.
-     */
-    void disconnect(void);
 
     /**
      * Terminates the io service and sets the shudown flag.

--- a/src/access_method_factory.cpp
+++ b/src/access_method_factory.cpp
@@ -198,15 +198,47 @@ static Binary_log_driver *parse_mysql_url(const char *body, size_t len)
 
   /* Find the port number */
   unsigned long portno = 3306;
-  if (*host_end == ':')
-    portno = strtoul(host_end + 1, NULL, 10);
+  const char *portno_end = host_end;
+  if (*host_end == ':') {
+    char *end;
+    portno = strtoul(host_end + 1, &end, 10);
+    portno_end = end;
+  }
   std::string user_str = UriDecode(std::string(user, user_end - user));
   std::string pass_str = UriDecode(std::string(pass, pass_end - pass));
   std::string host_str = UriDecode(std::string(host, host_end - host));
 
+  std::string binlog_file("");
+  unsigned long binlog_offset = 4;
+
+  /* Find binlog parameters */
+  const char *query_end = strpbrk(portno_end, "?");
+  if (query_end == 0) {
+    // no query part
+    query_end = portno_end;
+  } else {
+    while (*query_end == '?' || *query_end == '&' || *query_end == ';')
+    {
+      const char *key = query_end + 1;
+      const char *key_end = strpbrk(key, "=");
+      if (key_end == 0) // key is missing the following '='
+        return 0;
+      std::string key_str = UriDecode(std::string(key, key_end - key));
+      const char *value = key_end + 1;
+      const char *value_end = strpbrk(value, "&;#");
+      if (value_end == 0)
+        value_end = body + len;
+      if (key_str.compare("binlog_file") == 0)
+        binlog_file.assign(value, value_end - value);
+      else if (key_str.compare("binlog_offset") == 0)
+        binlog_offset = strtoul(value, NULL, 10);
+    }
+  }
+
   /* Host name is now the string [host, port-1) if port != NULL and [host, EOS) otherwise. */
   /* Port number is stored in portno, either the default, or a parsed one */
-  return new Binlog_tcp_driver(user_str, pass_str, host_str, portno);
+  return new Binlog_tcp_driver(user_str, pass_str, host_str, portno,
+                               binlog_file, binlog_offset);
 }
 
 

--- a/src/binary_log.cpp
+++ b/src/binary_log.cpp
@@ -123,6 +123,11 @@ int Binary_log::connect()
   }
 }
 
+int Binary_log::disconnect()
+{
+  return m_driver->disconnect();
+}
+
 int Binary_log::set_ssl_ca(const std::string& filepath)
 {
   return m_driver->set_ssl_ca(filepath);

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -784,7 +784,7 @@ void Binlog_tcp_driver::start_event_loop()
 
 int Binlog_tcp_driver::connect()
 {
-  return connect(m_user, m_passwd, m_host, m_port);
+  return connect(m_user, m_passwd, m_host, m_port, m_binlog_file_name, m_binlog_offset);
 }
 
 /**

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -812,7 +812,7 @@ void Binlog_tcp_driver::reconnect()
   connect(m_user, m_passwd, m_host, m_port);
 }
 
-void Binlog_tcp_driver::disconnect()
+int Binlog_tcp_driver::disconnect()
 {
   stop_binlog_dump();
   Binary_log_event * event;
@@ -828,6 +828,7 @@ void Binlog_tcp_driver::disconnect()
     m_socket->close();
   }
   m_socket= 0;
+  return ERR_OK;
 }
 
 
@@ -891,7 +892,7 @@ int Binlog_tcp_driver::set_position(const std::string &str, unsigned long positi
     against the server. The binlog dump command is executed asynchronously
     in another thread.
   */
-  
+
   int result = -1;
   if (is_valid_position) {
     result = connect(m_user, m_passwd, m_host, m_port, str, position);

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -1140,7 +1140,6 @@ int Binlog_tcp_driver::set_ssl_cipher(const std::string& cipher_list)
 
 int disconnect_server(Binlog_socket *binlog_socket)
 {
-  std::cout << "disconnect_server()\n" << std::flush;
   boost::asio::streambuf server_messages;
 
   std::ostream command_request_stream(&server_messages);
@@ -1172,10 +1171,8 @@ int disconnect_server(Binlog_socket *binlog_socket)
   {
     struct st_ok_package ok_package;
     prot_parse_ok_message(cmd_response_stream, ok_package, packet_length);
-    std::cout << "disconnect ok\n" << std::flush;
   } else
   {
-    std::cout << "disconnect failed\n" << std::flush;
     struct st_error_package error_package;
     prot_parse_error_message(cmd_response_stream, error_package, packet_length);
     throw std::runtime_error("Error from server, code=" + boost::lexical_cast<std::string>(error_package.error_code) + ", message=\"" + error_package.message + "\"");

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -56,6 +56,7 @@ static int encrypt_password(boost::uint8_t *reply,   /* buffer at least EVP_MAX_
                             const boost::uint8_t *scramble_buff,
                             const char *pass);
 static int hash_sha1(boost::uint8_t *output, ...);
+static int disconnect_server(Binlog_socket *binlog_socket);
 
     int Binlog_tcp_driver::connect(const std::string& user, const std::string& passwd,
                                    const std::string& host, long port,
@@ -806,8 +807,10 @@ void Binlog_tcp_driver::disconnect()
     m_event_queue->pop_back(&event);
     delete(event);
   }
-  if (m_socket)
+  if (m_socket) {
+    disconnect_server(m_socket);
     m_socket->close();
+  }
   m_socket= 0;
 }
 
@@ -1126,6 +1129,51 @@ int Binlog_tcp_driver::set_ssl_ca(const std::string& filepath)
 int Binlog_tcp_driver::set_ssl_cipher(const std::string& cipher_list)
 {
   m_opt_ssl_cipher= cipher_list;
+  return ERR_OK;
+}
+
+int disconnect_server(Binlog_socket *binlog_socket)
+{
+  std::cout << "disconnect_server()\n" << std::flush;
+  boost::asio::streambuf server_messages;
+
+  std::ostream command_request_stream(&server_messages);
+
+  boost::uint8_t val_command = COM_QUIT;
+  Protocol_chunk<boost::uint8_t> prot_command(val_command);
+
+  command_request_stream << prot_command;
+
+  // Send request
+  boost::this_thread::sleep_for(boost::chrono::seconds(1));
+  write_request(binlog_socket, server_messages, binlog_socket->reset_and_increment_packet_number());
+  boost::this_thread::sleep_for(boost::chrono::seconds(1));
+
+  // Get Ok-package
+  unsigned long packet_length;
+  unsigned char packet_no;
+  packet_length=proto_get_one_package(binlog_socket, server_messages, &packet_no);
+
+  std::istream cmd_response_stream(&server_messages);
+
+  boost::uint8_t result_type;
+  Protocol_chunk<boost::uint8_t> prot_result_type(result_type);
+
+  cmd_response_stream >> prot_result_type;
+
+
+  if (result_type == 0)
+  {
+    struct st_ok_package ok_package;
+    prot_parse_ok_message(cmd_response_stream, ok_package, packet_length);
+    std::cout << "disconnect ok\n" << std::flush;
+  } else
+  {
+    std::cout << "disconnect failed\n" << std::flush;
+    struct st_error_package error_package;
+    prot_parse_error_message(cmd_response_stream, error_package, packet_length);
+    throw std::runtime_error("Error from server, code=" + boost::lexical_cast<std::string>(error_package.error_code) + ", message=\"" + error_package.message + "\"");
+  }
   return ERR_OK;
 }
 


### PR DESCRIPTION
Issues
1. the process makes 2 binlog connections per connect() call.
2. each connection remains in MySQL "show processlist" indefinitely.

Solutions
1. Stop creating one of binlog connections.  To do it, the first (and the only) connection has to have the correct binlog position.
2. Create disconnect() function so that the user can close a connection explicitly.
3. Send COM_QUIT message to the server.

Key changes
1. Binlog_tcp_driver::connect() opens a connection with the binlog position set at the construction of the object.
2. Binlog_tcp_driver constructor takes a binlog file name and a binlog offset as arguments.
3. mysql::system::create_transport(const char* url) creates a Binlog_tcp_driver if a binlog position is specified in the given url.
4. mysql::system::create_transport(const char* url) accepts binlog position query attributes:
    - binlog_file
    - binlog_offset
    - ex) mysql://user:pass@localhost:3306/?binlog_file=mysql-logbin.000123&binlog_offset=4
5. Binlog_tcp_driver::disconnect() sends COM_QUIT to the server.
6. Added Binary_log::disconnect()