### PR TITLE
fix intermittent segfaults

### DIFF
--- a/include/field_iterator.h
+++ b/include/field_iterator.h
@@ -88,14 +88,12 @@ size_t Row_event_iterator<Iterator_value_type>::fields(Iterator_value_type& fiel
     ++row_field_col_index;
     unsigned int type= m_table_map->columns[col_no]&0xFF;
     boost::uint32_t metadata= extract_metadata(m_table_map, col_no);
+    bool m_is_null(is_null((unsigned char *)&nullbits[0], col_no ));
+    
     mysql::Value val((enum mysql::system::enum_field_types)type,
                      metadata,
-                     (const char *)&m_row_event->row[field_offset]);
-    if (is_null((unsigned char *)&nullbits[0], col_no ))
-    {
-      val.is_null(true);
-    }
-    else
+                     (const char *)&m_row_event->row[field_offset], m_is_null);
+    if(!m_is_null)
     {
        /*
         If the value is null it is not in the list of values and thus we won't
@@ -152,10 +150,12 @@ Row_event_iterator< Iterator_value_type >&
     for(unsigned col_no=0; col_no < m_table_map->columns.size(); ++col_no)
     {
       ++row_field_col_index;
+      bool m_is_null = is_null((unsigned char *)&nullbits[0], col_no);
       mysql::Value val((enum mysql::system::enum_field_types)m_table_map->columns[col_no],
                        m_table_map->metadata[col_no],
-                       (const char *)&m_row_event->row[m_field_offset]);
-      if (!is_null((unsigned char *)&nullbits[0], col_no))
+                       (const char *)&m_row_event->row[m_field_offset],
+                       m_is_null);
+      if (!m_is_null)
       {
         m_field_offset += val.length();
       }

--- a/include/value.h
+++ b/include/value.h
@@ -62,6 +62,17 @@ public:
                               metadata);
       //std::cout << "TYPE: " << type << " SIZE: " << m_size << std::endl;
     };
+    
+    Value(enum system::enum_field_types type, boost::uint32_t metadata, const char *storage, bool is_null) :
+      m_type(type), m_storage(storage), m_metadata(metadata), m_is_null(is_null)
+    {
+      if (!m_is_null){
+      m_size= calc_field_size((unsigned char)type,
+                              (const unsigned char*)storage,
+                              metadata);
+      }
+      //std::cout << "TYPE: " << type << " SIZE: " << m_size << std::endl;
+    };
 
     Value()
     {


### PR DESCRIPTION
It's been a couple months now since I fixed this, so I'm little hazy on the exact details, but I believe the problem was that it was trying to calculate the length of NULL fields.  Most of the time, this code would end up counting the length of other fields in the row update, but if the particular row update didn't have any other fields in the update or the NULL value was the last field in the update, it would segfault due to overrunning the array.

we've been running with this fix for several months now and not getting any segfaults any more.
