### PR TITLE
@B1160:R Fixed a bug where binlog parameters in URL were not parsed c…

### DIFF
--- a/include/binlog_driver.h
+++ b/include/binlog_driver.h
@@ -99,6 +99,8 @@ public:
 
   Binary_log_event* parse_event(std::istream &sbuff, Log_event_header *header);
 
+  const std::string& binlog_file_name() { return m_binlog_file_name; }
+  unsigned long binlog_offset() { return m_binlog_offset; }
 protected:
   /**
    * Used each time the client reconnects to the server to specify an

--- a/src/access_method_factory.cpp
+++ b/src/access_method_factory.cpp
@@ -240,8 +240,8 @@ static Binary_log_driver *parse_mysql_url(const char *body, size_t len)
         query_end = end;
         // std::cout << "binlog_offset:"  << binlog_offset << std::endl << std::flush;
       } else {
-        // ignore the key/value
-        query_end = value_end;
+        // Play safe and don't accept unsupported parameters to detect typo
+        return 0;
       }
     }
   }

--- a/src/access_method_factory.cpp
+++ b/src/access_method_factory.cpp
@@ -187,13 +187,14 @@ static Binary_log_driver *parse_mysql_url(const char *body, size_t len)
   /* Find the host name, which is mandatory */
   // Skip the '@', if there is one
   const char *host = *pass_end == '@' ? pass_end + 1 : pass_end;
-  const char *host_end = strchr(host, ':');
+  const char *host_end = strpbrk(host, ":?&;#");
   if (host == host_end)
     return 0;                                 // No hostname was found
   /* If no ':' was found there is no port, so the host end at the end
    * of the string */
-  if (host_end == 0)
+  if (host_end == 0) {
     host_end = body + len;
+  }
   assert(host_end - host >= 1);              // There has to be a host
 
   /* Find the port number */
@@ -212,7 +213,7 @@ static Binary_log_driver *parse_mysql_url(const char *body, size_t len)
   unsigned long binlog_offset = 4;
 
   /* Find binlog parameters */
-  const char *query_end = strpbrk(portno_end, "?");
+  const char *query_end = strpbrk(portno_end, "?&;");
   if (query_end == 0) {
     // no query part
     query_end = portno_end;
@@ -226,12 +227,22 @@ static Binary_log_driver *parse_mysql_url(const char *body, size_t len)
       std::string key_str = UriDecode(std::string(key, key_end - key));
       const char *value = key_end + 1;
       const char *value_end = strpbrk(value, "&;#");
-      if (value_end == 0)
+      if (value_end == 0) {
         value_end = body + len;
-      if (key_str.compare("binlog_file") == 0)
-        binlog_file.assign(value, value_end - value);
-      else if (key_str.compare("binlog_offset") == 0)
-        binlog_offset = strtoul(value, NULL, 10);
+      }
+      if (key_str.compare("binlog_file") == 0) {
+        binlog_file = UriDecode(std::string(value, value_end - value));
+        // std::cout << "binlog_file:" << binlog_file << std::endl << std::flush;
+        query_end = value_end;
+      } else if (key_str.compare("binlog_offset") == 0) {
+        char *end;
+        binlog_offset = strtoul(value, &end, 10);
+        query_end = end;
+        // std::cout << "binlog_offset:"  << binlog_offset << std::endl << std::flush;
+      } else {
+        // ignore the key/value
+        query_end = value_end;
+      }
     }
   }
 

--- a/tests/test-transport.cpp
+++ b/tests/test-transport.cpp
@@ -107,15 +107,11 @@ TEST_F(TestTransport, CreateTransport_TcpIp) {
                    "somebody", "magic", "128.0.0.1", 3306, "", 483928);
   TestTcpTransport("mysql://somebody:magic@128.0.0.1:3306?binlog_file=mysql-binlog.000001",
                    "somebody", "magic", "128.0.0.1", 3306, "mysql-binlog.000001", 4);
-  TestTcpTransport("mysql://somebody:magic@128.0.0.1:3306?unknown_key=1",
-                   "somebody", "magic", "128.0.0.1", 3306, "", 4);
   // It accpets a query not starting with ? even though it's not a correct syntax.
   TestTcpTransport("mysql://somebody:magic@128.0.0.1:3306&binlog_file=mysql-binlog.000001&binlog_offset=483928",
                    "somebody", "magic", "128.0.0.1", 3306, "mysql-binlog.000001", 483928);
   TestTcpTransport("mysql://somebody:magic@128.0.0.1:3306;binlog_file=mysql-binlog.000001;binlog_offset=483928",
                    "somebody", "magic", "128.0.0.1", 3306, "mysql-binlog.000001", 483928);
-  TestTcpTransport("mysql://somebody:magic@128.0.0.1:3306?unknown_param=mysql-binlog.000001&binlog_offset=483928",
-                   "somebody", "magic", "128.0.0.1", 3306, "", 483928);
   TestTcpTransport("mysql://somebody@128.0.0.1:3306?binlog_file=mysql-binlog.000001&binlog_offset=483928#test",
                    "somebody", "", "128.0.0.1", 3306, "mysql-binlog.000001", 483928);
   TestTcpTransport("mysql://somebody@128.0.0.1:3306?binlog_file=mysql-binlog.000001#test",
@@ -135,6 +131,11 @@ TEST_F(TestTransport, CreateTransport_TcpIp) {
   EXPECT_FALSE(create_transport("mysql://somebody@:99999"));
   EXPECT_FALSE(create_transport("mysql://somebody"));
   EXPECT_FALSE(create_transport("mysql://somebody:xyzzy"));
+
+
+  // Unsupported query parameter
+  EXPECT_FALSE(create_transport("mysql://somebody:magic@128.0.0.1:3306?binlog_file_name=mysql-binlog.000001&binlog_offset=483928"));
+  EXPECT_FALSE(create_transport("mysql://somebody:magic@128.0.0.1:3306?binlog_position=4"));
 }
 
 TEST_F(TestTransport, CreateTransport_File) {


### PR DESCRIPTION
…orrectly

Key changes
1. Accept '&' at the top of query part instead of '?' for fail-safe
2. Fixed a parse bug where it went to an infinite loop
3. Added handling for the fragment part '#'
