### PR TITLE
Feature/graceful disconnect

### DIFF
--- a/include/binlog_socket.h
+++ b/include/binlog_socket.h
@@ -3,7 +3,6 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
-#include <iostream>
 
 using boost::asio::ip::tcp;
 
@@ -51,7 +50,6 @@ public:
 
   void close()
   {
-    std::cout << "shutdown and close\n" << std::flush;
     m_socket->shutdown(tcp::socket::shutdown_both);
     m_socket->close();
   }

--- a/include/binlog_socket.h
+++ b/include/binlog_socket.h
@@ -3,6 +3,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
+#include <iostream>
 
 using boost::asio::ip::tcp;
 
@@ -50,17 +51,9 @@ public:
 
   void close()
   {
+    std::cout << "shutdown and close\n" << std::flush;
+    m_socket->shutdown(tcp::socket::shutdown_both);
     m_socket->close();
-  }
-
-  void cancel()
-  {
-    m_socket->cancel();
-  }
-
-  boost::asio::io_service &get_io_service()
-  {
-    m_socket->get_io_service();
   }
 
   bool is_ssl()

--- a/include/binlog_socket.h
+++ b/include/binlog_socket.h
@@ -53,6 +53,16 @@ public:
     m_socket->close();
   }
 
+  void cancel()
+  {
+    m_socket->cancel();
+  }
+
+  boost::asio::io_service &get_io_service()
+  {
+    m_socket->get_io_service();
+  }
+
   bool is_ssl()
   {
     return m_ssl_flag;

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -30,11 +30,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 
 #define MAX_PACKAGE_SIZE 0xffffff
 
-#define GET_NEXT_PACKET_HEADER   \
-   m_socket->async_read(boost::asio::buffer(m_net_header, 4), \
-     boost::bind(&Binlog_tcp_driver::handle_net_packet_header, this, \
-     boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred)) \
-
 using boost::asio::ip::tcp;
 
 namespace mysql { namespace system {

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -153,7 +153,7 @@ static int hash_sha1(boost::uint8_t *output, ...);
     boost::system::error_code ec;
     boost::asio::ip::address addr = boost::asio::ip::address::from_string(host, ec);
     if (ec) {
-      delete(binlog_socket);
+      delete binlog_socket;
       throw std::runtime_error("Host `" + host + "` not found");
     }
     tcp::endpoint ep(addr, port);
@@ -176,7 +176,7 @@ static int hash_sha1(boost::uint8_t *output, ...);
 
   if (error)
   {
-    delete(binlog_socket);
+    delete binlog_socket;
     throw std::runtime_error("Boost error: " + error.message());
   }
 
@@ -263,7 +263,7 @@ static int hash_sha1(boost::uint8_t *output, ...);
   unsigned char packet_no;
   if (proto_read_package_header(binlog_socket, server_messages, &packet_length, &packet_no))
   {
-    delete(binlog_socket);
+    delete binlog_socket;
     throw std::runtime_error("Invalid package header");
   }
 
@@ -294,7 +294,7 @@ static int hash_sha1(boost::uint8_t *output, ...);
    * Authenticate
    */
   if (authenticate(binlog_socket, user, passwd, handshake_package)){
-    delete(binlog_socket);
+    delete binlog_socket;
     throw std::runtime_error("Authentication failed.");
   }
 
@@ -406,7 +406,7 @@ static int hash_sha1(boost::uint8_t *output, ...);
   if (m_event_loop)
   {
     m_event_loop->join();
-    delete(m_event_loop);
+    delete m_event_loop;
     m_event_loop= 0;
   }
 }
@@ -828,9 +828,10 @@ int Binlog_tcp_driver::disconnect()
   while(m_event_queue->has_unread())
   {
     m_event_queue->pop_back(&event);
-    delete(event);
+    delete event;
   }
   m_socket->close();
+  delete m_socket;
   m_socket= 0;
   return ERR_OK;
 }

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -44,6 +44,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 #include "field_iterator.h"
 #include "binlog_socket.h"
 
+#define GET_NEXT_PACKET_HEADER   \
+   m_socket->async_read(boost::asio::buffer(m_net_header, 4), \
+     boost::bind(&Binlog_tcp_driver::handle_net_packet_header, this, \
+     boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred)) \
+
 using boost::asio::ip::tcp;
 using namespace mysql::system;
 using namespace mysql;


### PR DESCRIPTION
Key changes

1. `Binlog_socket::close()` calls to ensure graceful disconnect.
     http://www.boost.org/doc/libs/1_58_0/doc/html/boost_asio/reference/basic_stream_socket/close/overload2.html

2. Moved `GET_NEXT_PACKET_HEADER` from .h to .cpp.  This should've been defined in the .cpp in the first place.

3. Made `Binlog_tcp_driver::disconnect()` double-call-safe

4. Removed `disconnect_server()` function as it turned out that a MySQL slave does not send COM_QUIT when STOP SLAVE command is run.  It simply closes the connection.