### PR TITLE
@B1173:R flush event queue before joining thread to prevent the threa…

### DIFF
--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -182,6 +182,11 @@ private:
                                                  const std::string &host,
                                                  long port);
 
+    /**
+     * Drain events in the event queue
+     */
+    void drain_event_queue();
+
 
     boost::thread *m_event_loop;
     boost::asio::io_service m_io_service;
@@ -234,6 +239,7 @@ private:
      * A ring buffer used to dispatch aggregated events to the user application
      */
     bounded_buffer<Binary_log_event *> *m_event_queue;
+    boost::mutex m_event_queue_pop_back_mutex;
 
     std::string m_user;
     std::string m_host;


### PR DESCRIPTION
…d from being blocked by the full queue.

Key changes

1. disconnect() clears the event queue before joining the even loop thread.  
Since the consumer thread (wait_for_next_event) already stopped consuming events, there is a good chance that the queue becomes full.  A full event queue blocks the event loop from completing because it can't add an event to the queue.
Changed the code to empty the queue before joining the event loop thread.

2. wait_for_next_event() returns ERR::EOF as soon as disconnect() is called.  The idea is to stop processing events as soon as disconnect() is called as opposed to continue processing events which were in the queue.