### PR TITLE
Feature/u2519 json support

### DIFF
--- a/include/byte_order_generic.h
+++ b/include/byte_order_generic.h
@@ -1,0 +1,104 @@
+/* Copyright (c) 2001, 2014, Oracle and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+/*
+  Endianness-independent definitions for architectures other
+  than the x86 architecture.
+
+  (From include/byte_order_generic.h v5.7.16)
+*/
+
+#include <boost/asio.hpp>
+
+static inline boost::int16_t sint2korr(const uchar *A) { return *((boost::int16_t*) A); }
+
+static inline boost::int32_t sint4korr(const uchar *A) { return *((boost::int32_t*) A); }
+
+static inline boost::uint16_t uint2korr(const uchar *A) { return *((boost::uint16_t*) A); }
+
+static inline boost::uint32_t uint4korr(const uchar *A) { return *((boost::uint32_t*) A); }
+
+static inline ulonglong uint8korr(const uchar *A) { return *((ulonglong*) A);}
+
+static inline longlong  sint8korr(const uchar *A) { return *((longlong*) A); }
+
+
+static inline void int2store(uchar *T, boost::uint16_t A)
+{
+  *((boost::uint16_t*) T)= A;
+}
+
+static inline void int4store(uchar *T, boost::uint32_t A)
+{
+  *((boost::uint32_t*) T)= A;
+}
+
+static inline void int8store(uchar *T, ulonglong A)
+{
+  *((ulonglong*) T)= A;
+}
+
+
+static inline boost::int16_t sint2korr(const char *pT)
+{
+  return sint2korr(static_cast<const uchar*>(static_cast<const void*>(pT)));
+}
+
+static inline boost::uint16_t uint2korr(const char *pT)
+{
+  return uint2korr(static_cast<const uchar*>(static_cast<const void*>(pT)));
+}
+
+static inline boost::uint32_t uint4korr(const char *pT)
+{
+  return uint4korr(static_cast<const uchar*>(static_cast<const void*>(pT)));
+}
+
+static inline boost::int32_t sint4korr(const char *pT)
+{
+  return sint4korr(static_cast<const uchar*>(static_cast<const void*>(pT)));
+}
+
+static inline ulonglong uint8korr(const char *pT)
+{
+  return uint8korr(static_cast<const uchar*>(static_cast<const void*>(pT)));
+}
+
+static inline longlong  sint8korr(const char *pT)
+{
+  return sint8korr(static_cast<const uchar*>(static_cast<const void*>(pT)));
+}
+
+
+static inline void int2store(char *pT, boost::uint16_t A)
+{
+  int2store(static_cast<uchar*>(static_cast<void*>(pT)), A);
+}
+
+static inline void int4store(char *pT, boost::uint32_t A)
+{
+  int4store(static_cast<uchar*>(static_cast<void*>(pT)), A);
+}
+
+static inline void int8store(char *pT, ulonglong A)
+{
+  int8store(static_cast<uchar*>(static_cast<void*>(pT)), A);
+}
+
+
+static inline void float8get  (double *V, const char *M)
+{
+  memcpy(V, static_cast<const uchar*>(static_cast<const void*>(M)), sizeof(double));
+}

--- a/include/json_binary.h
+++ b/include/json_binary.h
@@ -1,0 +1,280 @@
+#ifndef JSON_BINARY_INCLUDED
+#define JSON_BINARY_INCLUDED
+
+/* Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
+
+/**
+  @file
+
+  This file specifies the interface for serializing JSON values into
+  binary representation, and for reading values back from the binary
+  representation.
+
+  The binary format is as follows:
+
+  Each JSON value (scalar, object or array) has a one byte type
+  identifier followed by the actual value.
+
+  If the value is a JSON object, its binary representation will have a
+  header that contains:
+
+  - the member count
+  - the size of the binary value in bytes
+  - a list of pointers to each key
+  - a list of pointers to each value
+
+  The actual keys and values will come after the header, in the same
+  order as in the header.
+
+  Similarly, if the value is a JSON array, the binary representation
+  will have a header with
+
+  - the element count
+  - the size of the binary value in bytes
+  - a list of pointers to each value
+
+  followed by the actual values, in the same order as in the header.
+
+  @verbatim
+  doc ::= type value
+
+  type ::=
+      0x00 |       // small JSON object
+      0x01 |       // large JSON object
+      0x02 |       // small JSON array
+      0x03 |       // large JSON array
+      0x04 |       // literal (true/false/null)
+      0x05 |       // int16
+      0x06 |       // uint16
+      0x07 |       // int32
+      0x08 |       // uint32
+      0x09 |       // int64
+      0x0a |       // uint64
+      0x0b |       // double
+      0x0c |       // utf8mb4 string
+      0x0f         // custom data (any MySQL data type)
+
+  value ::=
+      object  |
+      array   |
+      literal |
+      number  |
+      string  |
+      custom-data
+
+  object ::= element-count size key-entry* value-entry* key* value*
+
+  array ::= element-count size value-entry* value*
+
+  // number of members in object or number of elements in array
+  element-count ::=
+      uint16 |  // if used in small JSON object/array
+      uint32    // if used in large JSON object/array
+
+  // number of bytes in the binary representation of the object or array
+  size ::=
+      uint16 |  // if used in small JSON object/array
+      uint32    // if used in large JSON object/array
+
+  key-entry ::= key-offset key-length
+
+  key-offset ::=
+      uint16 |  // if used in small JSON object
+      uint32    // if used in large JSON object
+
+  key-length ::= uint16    // key length must be less than 64KB
+
+  value-entry ::= type offset-or-inlined-value
+
+  // This field holds either the offset to where the value is stored,
+  // or the value itself if it is small enough to be inlined (that is,
+  // if it is a JSON literal or a small enough [u]int).
+  offset-or-inlined-value ::=
+      uint16 |   // if used in small JSON object/array
+      uint32     // if used in large JSON object/array
+
+  key ::= utf8mb4-data
+
+  literal ::=
+      0x00 |   // JSON null literal
+      0x01 |   // JSON true literal
+      0x02 |   // JSON false literal
+
+  number ::=  ....  // little-endian format for [u]int(16|32|64), whereas
+                    // double is stored in a platform-independent, eight-byte
+                    // format using float8store()
+
+  string ::= data-length utf8mb4-data
+
+  custom-data ::= custom-type data-length binary-data
+
+  custom-type ::= uint8   // type identifier that matches the
+                          // internal enum_field_types enum
+
+  data-length ::= uint8*  // If the high bit of a byte is 1, the length
+                          // field is continued in the next byte,
+                          // otherwise it is the last byte of the length
+                          // field. So we need 1 byte to represent
+                          // lengths up to 127, 2 bytes to represent
+                          // lengths up to 16383, and so on...
+  @endverbatim
+
+  (From sql/json_binary.h v5.7.16)
+*/
+
+
+#include "protocol.h"                   // enum_field_types
+
+namespace json_binary
+{
+
+/**
+  Class used for reading JSON values that are stored in the binary
+  format. Values are parsed lazily, so that only the parts of the
+  value that are interesting to the caller, are read. Array elements
+  can be looked up in constant time using the element() function.
+  Object members can be looked up in O(log n) time using the lookup()
+  function.
+*/
+class Value
+{
+public:
+  static Value parse(const char *data, size_t len);
+  enum enum_type
+  {
+    OBJECT, ARRAY, STRING, INT, UINT, DOUBLE,
+    LITERAL_NULL, LITERAL_TRUE, LITERAL_FALSE,
+    OPAQUE,
+    ERROR /* Not really a type. Used to signal that an
+             error was detected. */
+  };
+  /**
+    Does this value, and all of its members, represent a valid JSON
+    value?
+  */
+  bool is_valid() const;
+  enum_type type() const { return m_type; }
+  const char *get_data() const;
+  size_t get_data_length() const;
+  boost::int64_t get_int64() const;
+  boost::uint64_t get_uint64() const;
+  double get_double() const;
+  size_t element_count() const;
+  Value element(size_t pos) const;
+  Value key(size_t pos) const;
+  mysql::system::enum_field_types field_type() const;
+  Value lookup(const char *key, size_t len) const;
+  bool to_string(std::string &buf);
+
+  /** Constructor for values that represent literals or errors. */
+  explicit Value(enum_type t);
+  /** Constructor for values that represent ints or uints. */
+  explicit Value(enum_type t, boost::int64_t val);
+  /** Constructor for values that represent doubles. */
+  explicit Value(double val);
+  /** Constructor for values that represent strings. */
+  Value(const char *data, size_t len);
+  /**
+    Constructor for values that represent arrays or objects.
+
+    @param t type
+    @param data pointer to the start of the binary representation
+    @param element_count the number of elements or members in the value
+    @param bytes the number of bytes in the binary representation of the value
+    @param large true if the value should be stored in the large
+    storage format with 4 byte offsets instead of 2 byte offsets
+  */
+  Value(enum_type t, const char *data, size_t element_count, size_t bytes,
+        bool large);
+  /** Constructor for values that represent opaque data. */
+  Value(mysql::system::enum_field_types ft, const char *data, size_t len);
+
+  /** Copy constructor. */
+  Value(const Value &old)
+    : m_type(old.m_type), m_field_type(old.m_field_type), m_data(old.m_data),
+      m_element_count(old.m_element_count), m_length(old.m_length),
+      m_int_value(old.m_int_value), m_double_value(old.m_double_value),
+      m_large(old.m_large)
+  {}
+
+  /** Empty constructor. Produces a value that represents an error condition. */
+  Value()
+    : m_type(ERROR), m_field_type(mysql::system::MYSQL_TYPE_NULL), m_data(NULL),
+      m_element_count(-1), m_length(-1), m_int_value(-1),
+      m_double_value(0.0), m_large(false)
+  {}
+
+  /** Assignment operator. */
+  Value &operator=(const Value &from)
+  {
+    if (this != &from)
+    {
+      // Copy the entire from value into this.
+      new (this) Value(from);
+    }
+    return *this;
+  }
+
+private:
+  /** The type of the value. */
+  const enum_type m_type;
+  /**
+    The MySQL field type of the value, in case the type of the value is
+    OPAQUE. Otherwise, it is unused.
+  */
+  const mysql::system::enum_field_types m_field_type ;
+  /**
+    Pointer to the start of the binary representation of the value. Only
+    used by STRING, OBJECT and ARRAY.
+
+    The memory pointed to by this member is not owned by this Value
+    object. Callers that create Value objects must make sure that the
+    memory is not freed as long as the Value object is alive.
+  */
+  const char *m_data;
+  /**
+    Element count for arrays and objects. Unused for other types.
+  */
+  const size_t m_element_count;
+  /**
+    The full length (in bytes) of the binary representation of an array or
+    object, or the length of a string or opaque value. Unused for other types.
+  */
+  const size_t m_length;
+  /** The value if the type is INT or UINT. */
+  const boost::int64_t m_int_value;
+  /** The value if the type is DOUBLE. */
+  const double m_double_value;
+  /**
+    True if an array or an object uses the large storage format with 4
+    byte offsets instead of 2 byte offsets.
+  */
+  const bool m_large;
+
+};
+
+/**
+  Parse a JSON binary document.
+
+  @param[in] data  a pointer to the binary data
+  @param[in] len   the size of the binary document in bytes
+  @return an object that allows access to the contents of the document
+*/
+Value parse_binary(const char *data, size_t len);
+
+}
+
+#endif  /* JSON_BINARY_INCLUDED */

--- a/include/protocol.h
+++ b/include/protocol.h
@@ -26,6 +26,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 #include "binlog_socket.h"
 
 using boost::asio::ip::tcp;
+
+typedef unsigned char uchar;
+typedef unsigned int uint;
+typedef unsigned long long ulonglong;
+typedef long long longlong;
+
 namespace mysql {
 namespace system {
 
@@ -75,6 +81,24 @@ struct st_error_package
   boost::uint8_t  sql_state[5];
   std::string  message;
 };
+
+/**
+  (From include/my_global.h v5.7.16)
+*/
+#define INT_MIN64       (~0x7FFFFFFFFFFFFFFFLL)
+#define INT_MAX64       0x7FFFFFFFFFFFFFFFLL
+#define INT_MIN32       (~0x7FFFFFFFL)
+#define INT_MAX32       0x7FFFFFFFL
+#define UINT_MAX32      0xFFFFFFFFL
+#define INT_MIN24       (~0x007FFFFF)
+#define INT_MAX24       0x007FFFFF
+#define UINT_MAX24      0x00FFFFFF
+#define INT_MIN16       (~0x7FFF)
+#define INT_MAX16       0x7FFF
+#define UINT_MAX16      0xFFFF
+#define INT_MIN8        (~0x7F)
+#define INT_MAX8        0x7F
+#define UINT_MAX8       0xFF
 
 #define CLIENT_LONG_PASSWORD	1	/* new more secure passwords */
 #define CLIENT_FOUND_ROWS	2	/* Found instead of affected rows */

--- a/include/value.h
+++ b/include/value.h
@@ -62,7 +62,7 @@ public:
                               metadata);
       //std::cout << "TYPE: " << type << " SIZE: " << m_size << std::endl;
     };
-    
+
     Value(enum system::enum_field_types type, boost::uint32_t metadata, const char *storage, bool is_null) :
       m_type(type), m_storage(storage), m_metadata(metadata), m_is_null(is_null)
     {
@@ -156,6 +156,13 @@ public:
      * @param[out] size The size in bytes of the blob data.
      */
     unsigned char *as_blob(unsigned long &size) const;
+
+    /**
+     * Append the JSON string to the given buffer.
+     *
+     * @param[out] buf The string object that JSON string is appended
+     */
+    bool to_json_string(std::string &buf) const;
 
     float as_float() const;
     double as_double() const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ set(replication_sources
   binlog_driver.cpp basic_transaction_parser.cpp tcp_driver.cpp
   file_driver.cpp binary_log.cpp protocol.cpp value.cpp binlog_event.cpp
   resultset_iterator.cpp basic_transaction_parser.cpp
-  basic_content_handler.cpp utilities.cpp)
+  basic_content_handler.cpp utilities.cpp json_binary.cpp)
 
 # Configure for building static library
 add_library(replication_static STATIC ${replication_sources})

--- a/src/json_binary.cpp
+++ b/src/json_binary.cpp
@@ -1,0 +1,874 @@
+/* Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+
+   This program is free software; you can rediostringstreamstribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
+
+/*
+  (From sql/json_binary.cc v5.7.16)
+ */
+
+#include "json_binary.h"
+#include "byte_order_generic.h"
+#include <algorithm>            // std::min
+#include <iostream>
+
+#define JSONB_TYPE_SMALL_OBJECT   0x0
+#define JSONB_TYPE_LARGE_OBJECT   0x1
+#define JSONB_TYPE_SMALL_ARRAY    0x2
+#define JSONB_TYPE_LARGE_ARRAY    0x3
+#define JSONB_TYPE_LITERAL        0x4
+#define JSONB_TYPE_INT16          0x5
+#define JSONB_TYPE_UINT16         0x6
+#define JSONB_TYPE_INT32          0x7
+#define JSONB_TYPE_UINT32         0x8
+#define JSONB_TYPE_INT64          0x9
+#define JSONB_TYPE_UINT64         0xA
+#define JSONB_TYPE_DOUBLE         0xB
+#define JSONB_TYPE_STRING         0xC
+#define JSONB_TYPE_OPAQUE         0xF
+
+#define JSONB_NULL_LITERAL        '\x00'
+#define JSONB_TRUE_LITERAL        '\x01'
+#define JSONB_FALSE_LITERAL       '\x02'
+
+/*
+  The size of offset or size fields in the small and the large storage
+  format for JSON objects and JSON arrays.
+*/
+#define SMALL_OFFSET_SIZE         2
+#define LARGE_OFFSET_SIZE         4
+
+/*
+  The size of key entries for objects when using the small storage
+  format or the large storage format. In the small format it is 4
+  bytes (2 bytes for key length and 2 bytes for key offset). In the
+  large format it is 6 (2 bytes for length, 4 bytes for offset).
+*/
+#define KEY_ENTRY_SIZE_SMALL      (2 + SMALL_OFFSET_SIZE)
+#define KEY_ENTRY_SIZE_LARGE      (2 + LARGE_OFFSET_SIZE)
+
+/*
+  The size of value entries for objects or arrays. When using the
+  small storage format, the entry size is 3 (1 byte for type, 2 bytes
+  for offset). When using the large storage format, it is 5 (1 byte
+  for type, 4 bytes for offset).
+*/
+#define VALUE_ENTRY_SIZE_SMALL    (1 + SMALL_OFFSET_SIZE)
+#define VALUE_ENTRY_SIZE_LARGE    (1 + LARGE_OFFSET_SIZE)
+
+#define DBUG_ASSERT(A) assert(A)
+
+namespace json_binary
+{
+
+/**
+  Read a variable length written by append_variable_length().
+
+  @param[in] data  the buffer to read from
+  @param[in] data_length  the maximum number of bytes to read from data
+  @param[out] length  the length that was read
+  @param[out] num  the number of bytes needed to represent the length
+  @return  false on success, true on error
+*/
+static bool read_variable_length(const char *data, size_t data_length,
+                                 size_t *length, size_t *num)
+{
+  /*
+    It takes five bytes to represent UINT_MAX32, which is the largest
+    supported length, so don't look any further.
+  */
+  const size_t max_bytes= std::min(data_length, static_cast<size_t>(5));
+
+  size_t len= 0;
+  for (size_t i= 0; i < max_bytes; i++)
+  {
+    // Get the next 7 bits of the length.
+    len|= (data[i] & 0x7f) << (7 * i);
+    if ((data[i] & 0x80) == 0)
+    {
+      // The length shouldn't exceed 32 bits.
+      if (len > UINT_MAX32)
+        return true;                          /* purecov: inspected */
+
+      // This was the last byte. Return successfully.
+      *num= i + 1;
+      *length= len;
+      return false;
+    }
+  }
+
+  // No more available bytes. Return true to signal error.
+  return true;                                /* purecov: inspected */
+}
+
+
+// Constructor for literals and errors.
+Value::Value(enum_type t)
+  : m_type(t), m_field_type(), m_data(), m_element_count(), m_length(),
+    m_int_value(), m_double_value(), m_large()
+{
+  DBUG_ASSERT(t == LITERAL_NULL || t == LITERAL_TRUE || t == LITERAL_FALSE ||
+              t == ERROR);
+}
+
+
+// Constructor for int and uint.
+Value::Value(enum_type t, boost::int64_t val)
+  : m_type(t), m_field_type(), m_data(), m_element_count(), m_length(),
+    m_int_value(val), m_double_value(), m_large()
+{
+  DBUG_ASSERT(t == INT || t == UINT);
+}
+
+
+// Constructor for double.
+Value::Value(double d)
+  : m_type(DOUBLE), m_field_type(), m_data(), m_element_count(), m_length(),
+    m_int_value(), m_double_value(d), m_large()
+{}
+
+
+// Constructor for string.
+Value::Value(const char *data, size_t len)
+  : m_type(STRING), m_field_type(), m_data(data), m_element_count(),
+    m_length(len), m_int_value(), m_double_value(), m_large()
+{}
+
+
+// Constructor for arrays and objects.
+Value::Value(enum_type t, const char *data, size_t bytes,
+             size_t element_count, bool large)
+  : m_type(t), m_field_type(), m_data(data), m_element_count(element_count),
+    m_length(bytes), m_int_value(), m_double_value(), m_large(large)
+{
+  DBUG_ASSERT(t == ARRAY || t == OBJECT);
+}
+
+
+// Constructor for opaque values.
+Value::Value(mysql::system::enum_field_types ft, const char *data, size_t len)
+  : m_type(OPAQUE), m_field_type(ft), m_data(data), m_element_count(),
+    m_length(len), m_int_value(), m_double_value(), m_large()
+{}
+
+
+bool Value::is_valid() const
+{
+  switch (m_type)
+  {
+  case ERROR:
+    return false;
+  case ARRAY:
+    // Check that all the array elements are valid.
+    for (size_t i= 0; i < element_count(); i++)
+      if (!element(i).is_valid())
+        return false;                         /* purecov: inspected */
+    return true;
+  case OBJECT:
+    {
+      /*
+        Check that all keys and values are valid, and that the keys come
+        in the correct order.
+      */
+      const char *prev_key= NULL;
+      size_t prev_key_len= 0;
+      for (size_t i= 0; i < element_count(); i++)
+      {
+        Value k= key(i);
+        if (!k.is_valid() || !element(i).is_valid())
+          return false;                       /* purecov: inspected */
+        const char *curr_key= k.get_data();
+        size_t curr_key_len= k.get_data_length();
+        if (i > 0)
+        {
+          if (prev_key_len > curr_key_len)
+            return false;                     /* purecov: inspected */
+          if (prev_key_len == curr_key_len &&
+              (memcmp(prev_key, curr_key, curr_key_len) >= 0))
+            return false;                     /* purecov: inspected */
+        }
+        prev_key= curr_key;
+        prev_key_len= curr_key_len;
+      }
+      return true;
+    }
+  default:
+    // This is a valid scalar value.
+    return true;
+  }
+}
+
+
+/**
+  Get a pointer to the beginning of the STRING or OPAQUE data
+  represented by this instance.
+*/
+const char *Value::get_data() const
+{
+  DBUG_ASSERT(m_type == STRING || m_type == OPAQUE);
+  return m_data;
+}
+
+
+/**
+  Get the length in bytes of the STRING or OPAQUE value represented by
+  this instance.
+*/
+size_t Value::get_data_length() const
+{
+  DBUG_ASSERT(m_type == STRING || m_type == OPAQUE);
+  return m_length;
+}
+
+
+/**
+  Get the value of an INT.
+*/
+boost::int64_t Value::get_int64() const
+{
+  DBUG_ASSERT(m_type == INT);
+  return m_int_value;
+}
+
+
+/**
+  Get the value of a UINT.
+*/
+boost::uint64_t Value::get_uint64() const
+{
+  DBUG_ASSERT(m_type == UINT);
+  return static_cast<boost::uint64_t>(m_int_value);
+}
+
+
+/**
+  Get the value of a DOUBLE.
+*/
+double Value::get_double() const
+{
+  DBUG_ASSERT(m_type == DOUBLE);
+  return m_double_value;
+}
+
+
+/**
+  Get the number of elements in an array, or the number of members in
+  an object.
+*/
+size_t Value::element_count() const
+{
+  DBUG_ASSERT(m_type == ARRAY || m_type == OBJECT);
+  return m_element_count;
+}
+
+
+/**
+  Get the MySQL field type of an opaque value. Identifies the type of
+  the value stored in the data portion of an opaque value.
+*/
+mysql::system::enum_field_types Value::field_type() const
+{
+  DBUG_ASSERT(m_type == OPAQUE);
+  return m_field_type;
+}
+
+
+/**
+  Create a Value object that represents an error condition.
+*/
+static Value err()
+{
+  return Value(Value::ERROR);
+}
+
+
+/**
+  Parse a JSON scalar value.
+
+  @param type   the binary type of the scalar
+  @param data   pointer to the start of the binary representation of the scalar
+  @param len    the maximum number of bytes to read from data
+  @return  an object that represents the scalar value
+*/
+static Value parse_scalar(boost::uint8_t type, const char *data, size_t len)
+{
+  switch (type)
+  {
+  case JSONB_TYPE_LITERAL:
+    if (len < 1)
+      return err();                           /* purecov: inspected */
+    switch (static_cast<boost::uint8_t>(*data))
+    {
+    case JSONB_NULL_LITERAL:
+      return Value(Value::LITERAL_NULL);
+    case JSONB_TRUE_LITERAL:
+      return Value(Value::LITERAL_TRUE);
+    case JSONB_FALSE_LITERAL:
+      return Value(Value::LITERAL_FALSE);
+    default:
+      return err();                           /* purecov: inspected */
+    }
+  case JSONB_TYPE_INT16:
+    if (len < 2)
+      return err();                           /* purecov: inspected */
+    return Value(Value::INT, sint2korr(data));
+  case JSONB_TYPE_INT32:
+    if (len < 4)
+      return err();                           /* purecov: inspected */
+    return Value(Value::INT, sint4korr(data));
+  case JSONB_TYPE_INT64:
+    if (len < 8)
+      return err();                           /* purecov: inspected */
+    return Value(Value::INT, sint8korr(data));
+  case JSONB_TYPE_UINT16:
+    if (len < 2)
+      return err();                           /* purecov: inspected */
+    return Value(Value::UINT, uint2korr(data));
+  case JSONB_TYPE_UINT32:
+    if (len < 4)
+      return err();                           /* purecov: inspected */
+    return Value(Value::UINT, uint4korr(data));
+  case JSONB_TYPE_UINT64:
+    if (len < 8)
+      return err();                           /* purecov: inspected */
+    return Value(Value::UINT, uint8korr(data));
+  case JSONB_TYPE_DOUBLE:
+    {
+      if (len < 8)
+        return err();                         /* purecov: inspected */
+      double d;
+      float8get(&d, data);
+      return Value(d);
+    }
+  case JSONB_TYPE_STRING:
+    {
+      size_t str_len;
+      size_t n;
+      if (read_variable_length(data, len, &str_len, &n))
+        return err();                         /* purecov: inspected */
+      if (len < n + str_len)
+        return err();                         /* purecov: inspected */
+      return Value(data + n, str_len);
+    }
+  case JSONB_TYPE_OPAQUE:
+    {
+      /*
+        There should always be at least one byte, which tells the field
+        type of the opaque value.
+      */
+      if (len < 1)
+        return err();                         /* purecov: inspected */
+
+      // The type is encoded as a uint8 that maps to an enum_field_types.
+      boost::uint8_t type_byte= static_cast<boost::uint8_t>(*data);
+      mysql::system::enum_field_types field_type= static_cast<mysql::system::enum_field_types>(type_byte);
+
+      // Then there's the length of the value.
+      size_t val_len;
+      size_t n;
+      if (read_variable_length(data + 1, len - 1, &val_len, &n))
+        return err();                         /* purecov: inspected */
+      if (len < 1 + n + val_len)
+        return err();                         /* purecov: inspected */
+      return Value(field_type, data + 1 + n, val_len);
+    }
+  default:
+    // Not a valid scalar type.
+    return err();
+  }
+}
+
+
+/**
+  Read an offset or size field from a buffer. The offset could be either
+  a two byte unsigned integer or a four byte unsigned integer.
+
+  @param data  the buffer to read from
+  @param large tells if the large or small storage format is used; true
+               means read four bytes, false means read two bytes
+*/
+static size_t read_offset_or_size(const char *data, bool large)
+{
+  return large ? uint4korr(data) : uint2korr(data);
+}
+
+
+/**
+  Parse a JSON array or object.
+
+  @param t      type (either ARRAY or OBJECT)
+  @param data   pointer to the start of the array or object
+  @param len    the maximum number of bytes to read from data
+  @param large  if true, the array or object is stored using the large
+                storage format; otherwise, it is stored using the small
+                storage format
+  @return  an object that allows access to the array or object
+*/
+static Value parse_array_or_object(Value::enum_type t, const char *data,
+                                   size_t len, bool large)
+{
+  DBUG_ASSERT(t == Value::ARRAY || t == Value::OBJECT);
+
+  /*
+    Make sure the document is long enough to contain the two length fields
+    (both number of elements or members, and number of bytes).
+  */
+  const size_t offset_size= large ? LARGE_OFFSET_SIZE : SMALL_OFFSET_SIZE;
+  if (len < 2 * offset_size)
+    return err();
+  const size_t element_count= read_offset_or_size(data, large);
+  const size_t bytes= read_offset_or_size(data + offset_size, large);
+
+  // The value can't have more bytes than what's available in the data buffer.
+  if (bytes > len)
+    return err();
+
+  /*
+    Calculate the size of the header. It consists of:
+    - two length fields
+    - if it is a JSON object, key entries with pointers to where the keys
+      are stored
+    - value entries with pointers to where the actual values are stored
+  */
+  size_t header_size= 2 * offset_size;
+  if (t == Value::OBJECT)
+    header_size+= element_count *
+      (large ? KEY_ENTRY_SIZE_LARGE : KEY_ENTRY_SIZE_SMALL);
+  header_size+= element_count *
+    (large ? VALUE_ENTRY_SIZE_LARGE : VALUE_ENTRY_SIZE_SMALL);
+
+  // The header should not be larger than the full size of the value.
+  if (header_size > bytes)
+    return err();                             /* purecov: inspected */
+
+  return Value(t, data, bytes, element_count, large);
+}
+
+
+/**
+  Parse a JSON value within a larger JSON document.
+
+  @param type   the binary type of the value to parse
+  @param data   pointer to the start of the binary representation of the value
+  @param len    the maximum number of bytes to read from data
+  @return  an object that allows access to the value
+*/
+static Value parse_value(boost::uint8_t type, const char *data, size_t len)
+{
+  switch (type)
+  {
+  case JSONB_TYPE_SMALL_OBJECT:
+    return parse_array_or_object(Value::OBJECT, data, len, false);
+  case JSONB_TYPE_LARGE_OBJECT:
+    return parse_array_or_object(Value::OBJECT, data, len, true);
+  case JSONB_TYPE_SMALL_ARRAY:
+    return parse_array_or_object(Value::ARRAY, data, len, false);
+  case JSONB_TYPE_LARGE_ARRAY:
+    return parse_array_or_object(Value::ARRAY, data, len, true);
+  default:
+    return parse_scalar(type, data, len);
+  }
+}
+
+
+Value parse_binary(const char *data, size_t len)
+{
+  // Each document should start with a one-byte type specifier.
+  if (len < 1)
+    return err();                             /* purecov: inspected */
+
+  return parse_value(data[0], data + 1, len - 1);
+}
+
+
+/**
+  Get the element at the specified position of a JSON array or a JSON
+  object. When called on a JSON object, it returns the value
+  associated with the key returned by key(pos).
+
+  @param pos  the index of the element
+  @return a value representing the specified element, or a value where
+  type() returns ERROR if pos does not point to an element
+*/
+Value Value::element(size_t pos) const
+{
+  DBUG_ASSERT(m_type == ARRAY || m_type == OBJECT);
+
+  if (pos >= m_element_count)
+    return err();
+
+  /*
+    Value entries come after the two length fields if it's an array, or
+    after the two length fields and all the key entries if it's an object.
+  */
+  size_t first_entry_offset=
+    2 * (m_large ? LARGE_OFFSET_SIZE : SMALL_OFFSET_SIZE);
+  if (type() == OBJECT)
+    first_entry_offset+=
+      m_element_count * (m_large ? KEY_ENTRY_SIZE_LARGE : KEY_ENTRY_SIZE_SMALL);
+
+  const size_t entry_size=
+    m_large ? VALUE_ENTRY_SIZE_LARGE : VALUE_ENTRY_SIZE_SMALL;
+  const size_t entry_offset= first_entry_offset + entry_size * pos;
+
+  boost::uint8_t type= m_data[entry_offset];
+
+  /*
+    Check if this is an inlined scalar value. If so, return it.
+    The scalar will be inlined just after the byte that identifies the
+    type, so it's found on entry_offset + 1.
+  */
+  if (type == JSONB_TYPE_INT16 || type == JSONB_TYPE_UINT16 ||
+      type == JSONB_TYPE_LITERAL ||
+      (m_large && (type == JSONB_TYPE_INT32 || type == JSONB_TYPE_UINT32)))
+    return parse_scalar(type, m_data + entry_offset + 1, entry_size - 1);
+
+  /*
+    Otherwise, it's a non-inlined value, and the offset to where the value
+    is stored, can be found right after the type byte in the entry.
+  */
+  size_t value_offset= read_offset_or_size(m_data + entry_offset + 1, m_large);
+
+  if (m_length < value_offset)
+    return err();                             /* purecov: inspected */
+
+  return parse_value(type, m_data + value_offset, m_length - value_offset);
+}
+
+
+/**
+  Get the key of the member stored at the specified position in a JSON
+  object.
+
+  @param pos  the index of the member
+  @return the key of the specified member, or a value where type()
+  returns ERROR if pos does not point to a member
+*/
+Value Value::key(size_t pos) const
+{
+  DBUG_ASSERT(m_type == OBJECT);
+
+  if (pos >= m_element_count)
+    return err();
+
+  const size_t offset_size= m_large ? LARGE_OFFSET_SIZE : SMALL_OFFSET_SIZE;
+  const size_t key_entry_size=
+    m_large ? KEY_ENTRY_SIZE_LARGE : KEY_ENTRY_SIZE_SMALL;
+  const size_t value_entry_size=
+    m_large ? VALUE_ENTRY_SIZE_LARGE : VALUE_ENTRY_SIZE_SMALL;
+
+  // The key entries are located after two length fields of size offset_size.
+  const size_t entry_offset= 2 * offset_size + key_entry_size * pos;
+
+  // The offset of the key is the first part of the key entry.
+  const size_t key_offset= read_offset_or_size(m_data + entry_offset, m_large);
+
+  // The length of the key is the second part of the entry, always two bytes.
+  const size_t key_length= uint2korr(m_data + entry_offset + offset_size);
+
+  /*
+    The key must start somewhere after the last value entry, and it must
+    end before the end of the m_data buffer.
+  */
+  if ((key_offset < entry_offset +
+                    (m_element_count - pos) * key_entry_size +
+                    m_element_count * value_entry_size) ||
+      (m_length < key_offset + key_length))
+    return err();                             /* purecov: inspected */
+
+  return Value(m_data + key_offset, key_length);
+}
+
+
+/**
+  Get the value associated with the specified key in a JSON object.
+
+  @param[in] key  pointer to the key
+  @param[in] len  length of the key
+  @return the value associated with the key, if there is one. otherwise,
+  returns ERROR
+*/
+Value Value::lookup(const char *key, size_t len) const
+{
+  DBUG_ASSERT(m_type == OBJECT);
+
+  const size_t offset_size=
+    (m_large ? LARGE_OFFSET_SIZE : SMALL_OFFSET_SIZE);
+
+  const size_t entry_size=
+    (m_large ? KEY_ENTRY_SIZE_LARGE : KEY_ENTRY_SIZE_SMALL);
+
+  // The first key entry is located right after the two length fields.
+  const size_t first_entry_offset= 2 * offset_size;
+
+  size_t lo= 0U;                // lower bound for binary search (inclusive)
+  size_t hi= m_element_count;   // upper bound for binary search (exclusive)
+
+  while (lo < hi)
+  {
+    // Find the entry in the middle of the search interval.
+    size_t idx= (lo + hi) / 2;
+    size_t entry_offset= first_entry_offset + idx * entry_size;
+
+    // Keys are ordered on length, so check length first.
+    size_t key_len= uint2korr(m_data + entry_offset + offset_size);
+    if (len > key_len)
+      lo= idx + 1;
+    else if (len < key_len)
+      hi= idx;
+    else
+    {
+      // The keys had the same length, so compare their contents.
+      size_t key_offset= read_offset_or_size(m_data + entry_offset, m_large);
+
+      int cmp= memcmp(key, m_data + key_offset, len);
+      if (cmp > 0)
+        lo= idx + 1;
+      else if (cmp < 0)
+        hi= idx;
+      else
+        return element(idx);
+    }
+  }
+
+  return err();
+}
+
+
+/**
+  Reserve space in a buffer. In order to avoid frequent reallocations,
+  allocate a new buffer at least as twice as large as the current
+  buffer if there is not enough space.
+
+  @param[in, out] buffer  the buffer in which to reserve space
+  @param[in]      needed  the number of bytes to reserve
+  @return false if successful, true if memory could not be allocated
+*/
+static void reserve(std::string &buf, size_t needed)
+{
+  size_t size =buf.size();
+  size += needed;
+  buf.reserve(size);
+}
+
+/*
+  _dig_vec arrays
+
+  (From strings/int2str.c v5.7.16)
+*/
+char _dig_vec_upper[] =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+char _dig_vec_lower[] =
+  "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/**
+  Perform quoting on a JSON string to make an external representation
+  of it. it wraps double quotes (text quotes) around the string (cptr)
+  an also performs escaping according to the following table:
+  <pre>
+  Common name     C-style  Original unescaped     Transformed to
+                  escape   UTF-8 bytes            escape sequence
+                  notation                        in UTF-8 bytes
+  ---------------------------------------------------------------
+  quote           \"       %x22                    %x5C %x22
+  backslash       \\       %x5C                    %x5C %x5C
+  backspace       \b       %x08                    %x5C %x62
+  formfeed        \f       %x0C                    %x5C %x66
+  linefeed        \n       %x0A                    %x5C %x6E
+  carriage-return \r       %x0D                    %x5C %x72
+  tab             \t       %x09                    %x5C %x74
+  unicode         \uXXXX  A hex number in the      %x5C %x75
+                          range of 00-1F,          followed by
+                          except for the ones      4 hex digits
+                          handled above (backspace,
+                          formfeed, linefeed,
+                          carriage-return,
+                          and tab).
+  ---------------------------------------------------------------
+  </pre>
+
+  @param[in] cptr pointer to string data
+  @param[in] length the length of the string
+  @param[in,out] buf the destination buffer
+  @retval false on success
+  @retval true on error
+
+  (From sql/json_dom.c v5.7.16)
+*/
+bool double_quote(const char *cptr, size_t length, std::string &buf)
+{
+  if (length < 1) {
+    return true;
+  }
+  for (size_t i= 0; i < length; i++)
+  {
+    char esc[2]= {'\\', cptr[i]};
+    bool done= true;
+    switch (cptr[i])
+    {
+    case '"' :
+    case '\\' :
+      break;
+    case '\b':
+      esc[1]= 'b';
+      break;
+    case '\f':
+      esc[1]= 'f';
+      break;
+    case '\n':
+      esc[1]= 'n';
+      break;
+    case '\r':
+      esc[1]= 'r';
+      break;
+    case '\t':
+      esc[1]= 't';
+      break;
+    default:
+      done= false;
+    }
+
+    if (done)
+    {
+        buf.append(esc, 2);
+    }
+    else if (((cptr[i] & ~0x7f) == 0) && // bit 8 not set
+             (cptr[i] < 0x1f))
+    {
+      /*
+        Unprintable control character, use hex a hexadecimal number.
+        The meaning of such a number determined by ISO/IEC 10646.
+      */
+      reserve(buf, 5);
+      buf.append("\\u00");
+      buf.append(&_dig_vec_lower[(cptr[i] & 0xf0) >> 4], 1);
+      buf.append(&_dig_vec_lower[(cptr[i] & 0x0f)], 1);
+    }
+    else
+    {
+      buf.append(&cptr[i], 1);
+    }
+  }
+  return true;
+}
+
+
+bool Value::to_string(std::string &buf)
+{
+  switch (m_type)
+  {
+  case ARRAY:
+  {
+    // Check that all the array elements are valid.
+    buf.append("[");
+    for (size_t i= 0; i < element_count(); i++) {
+      if (i>0) {
+        buf.append(", ");
+      }
+      Value v = element(i);
+      v.to_string(buf);
+    }
+    buf.append("]");
+    break;
+  }
+  case OBJECT:
+  {
+    buf.append("{");
+    for (size_t i= 0; i < element_count(); i++)
+    {
+      if (i>0) {
+        buf.append(", ");
+      }
+      Value k = key(i);
+      Value v = element(i);
+      const char *data = k.get_data();
+      size_t length = k.get_data_length();
+
+      // Append key
+      buf.append("\"");
+      double_quote(data, length, buf);
+      buf.append("\": ");
+      // Append value
+      v.to_string(buf);
+    }
+    buf.append("}");
+    break;
+  }
+  case STRING:
+  {
+    const char *data= get_data();
+    size_t length= get_data_length();
+    buf.append("\"");
+    double_quote(data, length, buf);
+    buf.append("\"");
+    break;
+  }
+  case INT:
+  {
+    std::ostringstream oss;
+    boost::int64_t i = get_int64();
+    oss << i;
+    buf.append(oss.str());
+    break;
+  }
+  case UINT:
+  {
+    std::ostringstream oss;
+    boost::uint64_t i = get_uint64();
+    oss << i;
+    buf.append(oss.str());
+    break;
+  }
+  case DOUBLE:
+  {
+    std::ostringstream oss;
+    double d = get_double();
+    oss << d;
+    buf.append(oss.str());
+    break;
+  }
+  case LITERAL_NULL:
+  {
+    buf.append("null");
+    break;
+  }
+  case LITERAL_TRUE:
+  {
+    buf.append("true");
+    break;
+  }
+  case LITERAL_FALSE:
+  {
+    buf.append("false");
+    break;
+  }
+  case OPAQUE:
+  {
+    // Dump a raw string
+    buf.append("\"");
+    buf.append(get_data(), get_data_length());
+    buf.append("\"");
+    break;
+  }
+  case ERROR:
+    buf.append("\"<<<< ERROR type detected >>>>\"");
+    return false;
+  default:
+    buf.append("\"<<<< Unsupported type detected >>>>\"");
+    return false;
+  }
+  return true;
+}
+
+
+} // end namespace json_binary

--- a/src/json_binary.cpp
+++ b/src/json_binary.cpp
@@ -831,8 +831,33 @@ bool Value::to_string(std::string &buf)
   }
   case DOUBLE:
   {
+    /*
+       TODO: Import dtoa.cc and calls the "my_gcvt()" function for converting a double value to string
+
+       Currently this implemention doesn't handle a double value accurately, if the precision of
+       the double value is the maximum precision(= 17 mostly). Since MySQL has its own implementation
+       to print a double value, eventually double values need to be converted through the "my_gcvt()"
+       function after importing the code in dtoa.cc.
+
+       Examples:
+         {"a": 1.8446744073709552e19} => {"a": 1.844674407370955e+19}
+         {"a": 1.0000000000000004}    => {"a": 1}
+
+       dtoa.cc
+         https://dev.mysql.com/doc/dev/mysql-server/latest/dtoa_8cc.html
+    */
     std::ostringstream oss;
     double d = get_double();
+
+    /*
+       Since "digits10 + 2" causes another issue for floating-point inaccuracy,
+       we decided not to show the last digit of the floating point.
+
+       Examples of issues if 'digits10 + 2' is set:
+         {"a": 1.33}                  => {"a": 1.3300000000000001}
+         {"a": 1.23456789}            => {"a": 1.2345678899999999}
+    */
+    oss.precision(std::numeric_limits<double>::digits10 + 1);
     oss << d;
     buf.append(oss.str());
     break;

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -55,8 +55,6 @@ using boost::asio::ip::tcp;
 using namespace mysql::system;
 using namespace mysql;
 
-typedef unsigned char uchar;
-
 namespace mysql { namespace system {
 
 static int encrypt_password(boost::uint8_t *reply,   /* buffer at least EVP_MAX_MD_SIZE */


### PR DESCRIPTION
This change is for supporting handling JSON type data as string.

My original implementation:
- src/json_binary.cpp
  - `bool Value::to_string(std::string &buf)`
- src/value.cpp
  - `bool Value::to_json_string(std::string &buf) const`

Note:
- Imported the logic which parses raw JSON data(BLOB format) from the MySQL(v5.7.16) source code.
  - Imported `include/json_binary.h`, `sql/json_binary.cc` and dependencies of them.
  - Replaced some MySQL specific types with boost types.
- One remaining issue is that the current implementation round the last digit of a double value if the precision of the value is maximum (= 17). This is because of floating-point inaccuracy. However, it should not be a problem in most of use cases.
  -  `dtoa.cc` included in the MySQL source code has implementation for printing double values for accurately. This needs to be imported to this project eventually.


